### PR TITLE
Rails Versions A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+*.gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ If you find a bug or have an idea for a feature:
 
 ## Testing
 
+There are automated tests, and test apps that allow you do manual testing and explore the gem.
+
 ### Manual and Exploratory Testing
 
 There are test apps in `test/rails_app`, for the default locale, and `es_rails_app` for a Spanish locale.
@@ -23,18 +25,28 @@ rails s -b 0.0.0.0 &
 # Navigate to localhost:3000/people/sign_in
 ```
 
+To change the version of Rails for the test app:
+
+```bash
+export BUNDLE_GEMFILE=gemfiles/7.0.gemfile # change this to the version of Rails you need
+bundle update
+rails s -b 0.0.0.0 &
+```
+
 ### Automated Testing
 
-To run the tests and the RuboCop checks:
+To test locally against a specific version of Rails, do the following:
+
+```bash
+export BUNDLE_GEMFILE=gemfiles/7.0.gemfile # change this to the version of Rails you need
+bundle update
+rake test
+```
+
+To run the tests and the RuboCop checks, assuming you've set the `BUNDLE_GEMFILE` as above:
 
 ```bash
 rake
-```
-
-To run just the tests:
-
-```bash
-rake test
 ```
 
 ## Gotchas

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -3,11 +3,12 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in devise-bootstrap-form.gemspec
-gemspec
+gemspec path: ".."
+
+# Set a Rails version compatible with a Ruby version
+gem "rails", "~> 5.2.0"
 
 group :development do
-  gem "chandler", ">= 0.7.0"
-  # gem "htmlbeautifier"
   gem "rubocop", require: false
   gem "rubocop-rake", require: false
 end

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -3,11 +3,12 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in devise-bootstrap-form.gemspec
-gemspec
+gemspec path: ".."
+
+# Set a Rails version compatible with a Ruby version
+gem "rails", "~> 6.0.0"
 
 group :development do
-  gem "chandler", ">= 0.7.0"
-  # gem "htmlbeautifier"
   gem "rubocop", require: false
   gem "rubocop-rake", require: false
 end

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -3,11 +3,12 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in devise-bootstrap-form.gemspec
-gemspec
+gemspec path: ".."
+
+# Set a Rails version compatible with a Ruby version
+gem "rails", "~> 6.1.0"
 
 group :development do
-  gem "chandler", ">= 0.7.0"
-  # gem "htmlbeautifier"
   gem "rubocop", require: false
   gem "rubocop-rake", require: false
 end

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -3,11 +3,12 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in devise-bootstrap-form.gemspec
-gemspec
+gemspec path: ".."
+
+# Set a Rails version compatible with a Ruby version
+gem "rails", "~> 7.0.0"
 
 group :development do
-  gem "chandler", ">= 0.7.0"
-  # gem "htmlbeautifier"
   gem "rubocop", require: false
   gem "rubocop-rake", require: false
 end

--- a/test/es_rails_app/gemfiles/5.2.gemfile
+++ b/test/es_rails_app/gemfiles/5.2.gemfile
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/StringLiterals
+
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '2.6.9'
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'rails', '~> 5.2.1'
+gem 'rails-i18n'
+# Use sqlite as the database for Active Record
+gem 'sqlite3'
+# Use Puma as the app server
+gem 'puma', '~> 3.11'
+# Use SCSS for stylesheets
+gem 'sassc-rails'
+# Use Uglifier as compressor for JavaScript assets
+gem 'uglifier', '>= 1.3.0'
+# See https://github.com/rails/execjs#readme for more supported runtimes
+# gem 'mini_racer', platforms: :ruby
+
+# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+gem 'turbolinks', '~> 5'
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 2.5'
+# Use Redis adapter to run Action Cable in production
+# gem 'redis', '~> 4.0'
+# Use ActiveModel has_secure_password
+# gem 'bcrypt', '~> 3.1.7'
+
+# Use ActiveStorage variant
+# gem 'mini_magick', '~> 4.8'
+
+# Use Capistrano for deployment
+# gem 'capistrano-rails', group: :development
+
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.1.0', require: false
+
+group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+end
+
+gem 'bootstrap', '~> 4.0.0'
+gem "bootstrap_form", ">= 4.0.0"
+gem 'devise-bootstrap-form', path: "../.."
+gem 'devise-i18n'
+gem 'devise_invitable'
+
+group :development do
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem 'capybara', '>= 2.15'
+  gem 'capybara-email'
+  gem 'selenium-webdriver'
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+# rubocop:enable Style/StringLiterals

--- a/test/rails_app/gemfiles/5.2.gemfile
+++ b/test/rails_app/gemfiles/5.2.gemfile
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/StringLiterals
+
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '2.6.9'
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'rails', '~> 5.2.1'
+# Use sqlite as the database for Active Record
+gem 'sqlite3'
+# Use Puma as the app server
+gem 'puma', '~> 3.11'
+# Use SCSS for stylesheets
+gem 'sassc-rails'
+# Use Uglifier as compressor for JavaScript assets
+gem 'uglifier', '>= 1.3.0'
+# See https://github.com/rails/execjs#readme for more supported runtimes
+# gem 'mini_racer', platforms: :ruby
+
+# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+gem 'turbolinks', '~> 5'
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 2.5'
+# Use Redis adapter to run Action Cable in production
+# gem 'redis', '~> 4.0'
+# Use ActiveModel has_secure_password
+# gem 'bcrypt', '~> 3.1.7'
+
+# Use ActiveStorage variant
+# gem 'mini_magick', '~> 4.8'
+
+# Use Capistrano for deployment
+# gem 'capistrano-rails', group: :development
+
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.1.0', require: false
+
+group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+end
+
+gem 'bootstrap', '~> 4.0.0'
+gem "bootstrap_form", ">= 4.0.0"
+gem 'devise'
+gem 'devise-bootstrap-form', path: "../.."
+gem 'devise_invitable'
+
+group :development do
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem 'capybara', '>= 2.15'
+  gem 'capybara-email'
+  gem 'selenium-webdriver'
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+# rubocop:enable Style/StringLiterals


### PR DESCRIPTION
Start creating some gemfiles to test different versions. This PR contains:

* Top-level gemfiles for 5.2 to 7.0. They're needed because the gem itself depends on any version of Rails after 5.2. It can be tricky to bootstrap an earlier version of Rails in development without the gemfiles that specify a specific Rails version.
* Rails 5.2 gemfiles for the two test apps.
