### PR TITLE
Make links buttons

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -12,6 +12,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -18,6 +18,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,6 +8,6 @@
     <%= f.submit "Send me reset password instructions", class: "btn btn-primary btn-lg" %>
   <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,6 +14,6 @@
     <%= f.submit "Sign up", class: "btn btn-primary btn-lg" %>
   <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,6 +13,6 @@
   <%= f.submit "Log in", class: "btn btn-primary btn-lg" %>
 <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,37 @@
 <%- if controller_name != "sessions" %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in",
+    new_session_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != "registrations" %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Sign up",
+    new_registration_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?",
+    new_password_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?",
+    new_confirmation_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?",
+    new_unlock_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}",
+      omniauth_authorize_path(resource_name, provider),
+      class: %w[btn btn-outline-secondary mb-3] %>
   <% end -%>
 <% end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,6 +9,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/confirmations/new.html.erb
+++ b/app/views/i18n/confirmations/new.html.erb
@@ -12,6 +12,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/passwords/edit.html.erb
+++ b/app/views/i18n/passwords/edit.html.erb
@@ -18,6 +18,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/passwords/new.html.erb
+++ b/app/views/i18n/passwords/new.html.erb
@@ -7,6 +7,6 @@
     <%= f.submit t(".send_me_reset_password_instructions"), class: "btn btn-primary btn-lg" %>
   <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/registrations/new.html.erb
+++ b/app/views/i18n/registrations/new.html.erb
@@ -14,6 +14,6 @@
     <%= f.submit t(".sign_up"), class: "btn btn-primary btn-lg" %>
   <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/sessions/new.html.erb
+++ b/app/views/i18n/sessions/new.html.erb
@@ -13,6 +13,6 @@
   <%= f.submit t(".sign_in"), class: "btn btn-primary btn-lg" %>
 <% end %>
 <% end %>
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/i18n/shared/_links.html.erb
+++ b/app/views/i18n/shared/_links.html.erb
@@ -1,25 +1,37 @@
 <%- if controller_name != "sessions" %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  <%= link_to t(".sign_in"),
+    new_session_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != "registrations" %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  <%= link_to t(".sign_up"),
+    new_registration_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <%= link_to t(".forgot_your_password"),
+    new_password_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
-  <%= link_to t(".didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name) %><br />
+  <%= link_to t(".didn_t_receive_confirmation_instructions"),
+    new_confirmation_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
-  <%= link_to t(".didn_t_receive_unlock_instructions"), new_unlock_path(resource_name) %><br />
+  <%= link_to t(".didn_t_receive_unlock_instructions"),
+    new_unlock_path(resource_name),
+    class: %w[btn btn-outline-secondary mb-3] %>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)),
+      omniauth_authorize_path(resource_name, provider),
+      class: %w[btn btn-outline-secondary mb-3] %>
   <% end -%>
 <% end -%>

--- a/app/views/i18n/unlocks/new.html.erb
+++ b/app/views/i18n/unlocks/new.html.erb
@@ -9,6 +9,6 @@
   <% end %>
 <% end %>
 
-<div class="text-center">
+<div class="d-grid">
   <%= render "devise/shared/links" %>
 </div>


### PR DESCRIPTION
The Bootstrap 4 version rendered the shared links as links, not buttons. But the principal link on any view was a button. This PR makes them all buttons.